### PR TITLE
Make regular expression resilient to // eslint-disable-next-line declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,9 @@ function ignoreError(error) {
 
   // The whitespace after `eslint-disable` is important so `eslint-disable-next-line` and variants
   // aren't picked up.
-  if (firstLine.includes('eslint-disable ')) {
-    const matched = firstLine.match(/eslint-disable(.*)\*\//);
+  const matched = firstLine.match(/eslint-disable (.*)\*\//);
+
+  if (matched) {
     const existing = matched[1].split(',').map((item) => item.trim());
     uniqueIds = [...new Set([...ruleIds, ...existing])];
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ function ignoreError(error) {
 
   const firstLine = file.split('\n')[0];
 
-  if (firstLine.includes('eslint-disable')) {
+  // The whitespace after `eslint-disable` is important so `eslint-disable-next-line` and variants
+  // aren't picked up.
+  if (firstLine.includes('eslint-disable ')) {
     const matched = firstLine.match(/eslint-disable(.*)\*\//);
     const existing = matched[1].split(',').map((item) => item.trim());
     uniqueIds = [...new Set([...ruleIds, ...existing])];

--- a/test/ignore.mjs
+++ b/test/ignore.mjs
@@ -56,4 +56,88 @@ debugger`);
     expect(result['test.js']).to.equal(`/* eslint-disable no-debugger */
 debugger`);
   });
+
+  it('should handle files with `// eslint-disable` comments', async function () {
+    this.timeout(20000);
+    const tempDir = await temp.mkdir('super-app');
+
+    fixturify.writeSync(tempDir, {
+      '.eslintrc.json': '{"extends": "eslint:recommended"}',
+      'test.js': `// eslint-disable no-debugger
+debugger`,
+      'package.json': `{
+  "devDependencies": {
+    "eslint": "^8.0.0"
+  }
+}
+`,
+    });
+
+    let result = await execa('npm', ['i'], { cwd: tempDir });
+
+    await ignoreAll(tempDir);
+
+    result = fixturify.readSync(tempDir);
+
+    expect(result['test.js']).to.equal(`/* eslint-disable no-debugger */
+debugger`);
+  });
+
+  it('should add to existing `/* eslint-disable` comments', async function () {
+    this.timeout(20000);
+    const tempDir = await temp.mkdir('super-app');
+
+    fixturify.writeSync(tempDir, {
+      '.eslintrc.json': '{"extends": "eslint:recommended"}',
+      'test.js': `/* eslint-disable no-console, no-undef */
+debugger
+console.log('test')`,
+      'package.json': `{
+  "devDependencies": {
+    "eslint": "^8.0.0"
+  }
+}
+`,
+    });
+
+    let result = await execa('npm', ['i'], { cwd: tempDir });
+
+    await ignoreAll(tempDir);
+
+    result = fixturify.readSync(tempDir);
+
+    expect(result['test.js']).to
+      .equal(`/* eslint-disable no-debugger, no-console, no-undef */
+debugger
+console.log('test')`);
+  });
+
+  it('handles `// eslint-disable-next-line` at the top of the file correctly', async function () {
+    this.timeout(20000);
+    const tempDir = await temp.mkdir('super-app');
+
+    fixturify.writeSync(tempDir, {
+      '.eslintrc.json': '{"extends": "eslint:recommended"}',
+      'test.js': `/* eslint-disable-next-line no-debugger */
+debugger
+console.log('test')`,
+      'package.json': `{
+  "devDependencies": {
+    "eslint": "^8.0.0"
+  }
+}
+`,
+    });
+
+    let result = await execa('npm', ['i'], { cwd: tempDir });
+
+    await ignoreAll(tempDir);
+
+    result = fixturify.readSync(tempDir);
+
+    expect(result['test.js']).to.equal(`/* eslint-disable no-undef */
+/* eslint-disable-next-line no-debugger */
+debugger
+console.log('test')`);
+  });
 });

--- a/test/ignore.mjs
+++ b/test/ignore.mjs
@@ -140,4 +140,31 @@ console.log('test')`,
 debugger
 console.log('test')`);
   });
+
+  it('handles rules with slashes in the name', async function () {
+    this.timeout(20000);
+    const tempDir = await temp.mkdir('super-app');
+
+    fixturify.writeSync(tempDir, {
+      '.eslintrc.json': '{"extends": "eslint:recommended"}',
+      'test.js': `/* eslint-disable ember/no-observers */
+debugger`,
+      'package.json': `{
+  "devDependencies": {
+    "eslint": "^8.0.0"
+  }
+}
+`,
+    });
+
+    let result = await execa('npm', ['i'], { cwd: tempDir });
+
+    await ignoreAll(tempDir);
+
+    result = fixturify.readSync(tempDir);
+
+    expect(result['test.js']).to
+      .equal(`/* eslint-disable ember/no-observers, no-debugger */
+debugger`);
+  });
 });

--- a/test/ignore.mjs
+++ b/test/ignore.mjs
@@ -57,7 +57,7 @@ debugger`);
 debugger`);
   });
 
-  it('should handle files with `// eslint-disable` comments', async function () {
+  it('should handle files with invalid `// eslint-disable` comments at the top', async function () {
     this.timeout(20000);
     const tempDir = await temp.mkdir('super-app');
 
@@ -80,6 +80,7 @@ debugger`,
     result = fixturify.readSync(tempDir);
 
     expect(result['test.js']).to.equal(`/* eslint-disable no-debugger */
+// eslint-disable no-debugger
 debugger`);
   });
 


### PR DESCRIPTION
This stops the ignore command from turning

```
// eslint-disable-next-line ember/no-classic-components
```

into

```
/* eslint-disable -next-line ember/no-classic-components */
```