### PR TITLE
Support shebang files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,33 +1,9 @@
 /* eslint-disable prettier/prettier */
 const { readFileSync, writeFileSync, lstatSync } = require('fs');
 const { join } = require('path');
-const importCwd = require('import-cwd');
 const walkSync = require('walk-sync');
-const semver = require('semver');
 
-function ignoreError(error) {
-  const ruleIds = error.messages.map((message) => message.ruleId);
-  let uniqueIds = [...new Set(ruleIds)];
-
-  const file = readFileSync(error.filePath, 'utf8');
-
-  const firstLine = file.split('\n')[0];
-
-  // The whitespace after `eslint-disable` is important so `eslint-disable-next-line` and variants
-  // aren't picked up.
-  const matched = firstLine.match(/eslint-disable (.*)\*\//);
-
-  if (matched) {
-    const existing = matched[1].split(',').map((item) => item.trim());
-    uniqueIds = [...new Set([...ruleIds, ...existing])];
-    uniqueIds.sort((a, b) => a.localeCompare(b));
-
-    writeFileSync(error.filePath, file.replace(/^.*\n/, `/* eslint-disable ${uniqueIds.join(', ')} */\n`));
-  } else {
-    uniqueIds.sort((a, b) => a.localeCompare(b));
-    writeFileSync(error.filePath, `/* eslint-disable ${uniqueIds.join(', ')} */\n${file}`);
-  }
-}
+const ignoreAll = require('./lib/ignore-all');
 
 function removeIgnore(filePath, rulename) {
   const file = readFileSync(filePath, 'utf8');
@@ -78,41 +54,6 @@ function getFiles(cwd, providedGlob) {
     ignore: ignoreFile || ['**/node_modules/*'],
     directories: false,
   });
-}
-
-async function ignoreAll(cwd = process.cwd()) {
-  const currentPackageJSON = require(join(cwd, 'package.json'));
-
-  const eslintVersion = currentPackageJSON.devDependencies.eslint;
-
-  let cli;
-  let report;
-  let results;
-
-  const eslint = importCwd('eslint');
-
-  if (semver.intersects(eslintVersion, '8')) {
-    // this won't use the version in the repo but it will still use v8 because
-    // that is installed in this repo
-    const { ESLint } = eslint;
-    cli = new ESLint();
-    results = await cli.lintFiles([cwd]);
-
-    // remove warnings
-    results = ESLint.getErrorResults(results);
-  } else {
-    const { CLIEngine, ESLint } = eslint;
-    cli = new CLIEngine();
-    report = cli.executeOnFiles([cwd]);
-    results = report.results;
-
-    // remove warnings
-    results = ESLint.getErrorResults(results);
-  }
-
-  const errors = results.filter((result) => result.errorCount > 0);
-
-  errors.forEach(ignoreError);
 }
 
 function list(cwd = process.cwd()) {

--- a/index.js
+++ b/index.js
@@ -1,42 +1,6 @@
-/* eslint-disable prettier/prettier */
-const { readFileSync, writeFileSync } = require('fs');
-const { join } = require('path');
-
 const ignoreAll = require('./lib/ignore-all');
 const list = require('./lib/list');
-const getFiles = require('./lib/get-files');
-
-function removeIgnore(filePath, rulename) {
-  const file = readFileSync(filePath, 'utf8');
-
-  const firstLine = file.split('\n')[0];
-
-  // The whitespace after `eslint-disable` is important so `eslint-disable-next-line` and variants
-  // aren't picked up.
-  const matched = firstLine.match(/eslint-disable (.*)\*\//);
-
-  if (matched) {
-    const existing = matched[1].split(',').map((item) => item.trim()).filter((item) => item !== rulename);
-
-    if (existing.length) {
-      writeFileSync(filePath, file.replace(/^.*\n/, `/* eslint-disable ${existing.join(', ')} */\n`));
-    } else {
-      writeFileSync(filePath, file.replace(/^.*\n/, ''));
-    }
-  }
-}
-
-function remove({name, filter} = {}, cwd = process.cwd()) {
-  if (!name) {
-    throw new Error('No rulename was passed to `remove()` in lint-to-the-future-eslint plugin');
-  }
-
-  const files = getFiles(cwd, filter);
-
-  files.forEach((relativeFilePath) => {
-    removeIgnore(join(cwd, relativeFilePath), name);
-  });
-}
+const remove = require('./lib/remove');
 
 module.exports = {
   ignoreAll,

--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -1,0 +1,34 @@
+const { readFileSync } = require('fs');
+const walkSync = require('walk-sync');
+const { join } = require('path');
+
+module.exports = function getFiles(cwd, providedGlob) {
+  let ignoreFile;
+
+  try {
+    ignoreFile = readFileSync(join(cwd, '.gitignore'), 'utf8')
+      .split('\n')
+      .filter((line) => line.length)
+      .filter((line) => !line.startsWith('#'))
+      // walkSync can't handle these
+      .filter((line) => !line.startsWith('!'))
+      .map((line) => line.replace(/^\//, ''))
+      .map((line) => line.replace(/\/$/, '/*'));
+  } catch (e) {
+    // noop
+  }
+
+  let globs;
+
+  if (providedGlob) {
+    globs = [providedGlob];
+  } else {
+    globs = ['**/*.js', '**/*.ts'];
+  }
+
+  return walkSync(cwd, {
+    globs,
+    ignore: ignoreFile || ['**/node_modules/*'],
+    directories: false,
+  });
+};

--- a/lib/ignore-all.js
+++ b/lib/ignore-all.js
@@ -5,11 +5,21 @@ const { readFileSync, writeFileSync } = require('fs');
 
 function ignoreError(error) {
   const ruleIds = error.messages.map((message) => message.ruleId);
-  let uniqueIds = [...new Set(ruleIds)];
+  let uniqueIds = [...new Set(ruleIds)].sort((a, b) => a.localeCompare(b));
 
   const file = readFileSync(error.filePath, 'utf8');
 
-  const firstLine = file.split('\n')[0];
+  const splitFile = file.split('\n');
+
+  let firstLine = splitFile[0];
+
+  // shebang https://nodejs.org/en/learn/command-line/run-nodejs-scripts-from-the-command-line
+  let shebangFile = firstLine.startsWith('#!');
+
+  // the logical first line of the file is after the shebang
+  if (shebangFile) {
+    firstLine = splitFile[1];
+  }
 
   // The whitespace after `eslint-disable` is important so `eslint-disable-next-line` and variants
   // aren't picked up.
@@ -17,20 +27,18 @@ function ignoreError(error) {
 
   if (matched) {
     const existing = matched[1].split(',').map((item) => item.trim());
-    uniqueIds = [...new Set([...ruleIds, ...existing])];
-    uniqueIds.sort((a, b) => a.localeCompare(b));
-
-    writeFileSync(
-      error.filePath,
-      file.replace(/^.*\n/, `/* eslint-disable ${uniqueIds.join(', ')} */\n`),
-    );
-  } else {
-    uniqueIds.sort((a, b) => a.localeCompare(b));
-    writeFileSync(
-      error.filePath,
-      `/* eslint-disable ${uniqueIds.join(', ')} */\n${file}`,
+    uniqueIds = [...new Set([...ruleIds, ...existing])].sort((a, b) =>
+      a.localeCompare(b),
     );
   }
+
+  splitFile.splice(
+    shebangFile ? 1 : 0, // if it's a shebangFile we start at the 2nd line of the file
+    matched ? 1 : 0, // if it's already got an eslint-disable we replace the line (i.e. delete one line before splicing)
+    `/* eslint-disable ${uniqueIds.join(', ')} */`,
+  );
+
+  writeFileSync(error.filePath, splitFile.join('\n'));
 }
 
 module.exports = async function ignoreAll(cwd = process.cwd()) {

--- a/lib/ignore-all.js
+++ b/lib/ignore-all.js
@@ -1,0 +1,69 @@
+const { join } = require('path');
+const importCwd = require('import-cwd');
+const semver = require('semver');
+const { readFileSync, writeFileSync } = require('fs');
+
+function ignoreError(error) {
+  const ruleIds = error.messages.map((message) => message.ruleId);
+  let uniqueIds = [...new Set(ruleIds)];
+
+  const file = readFileSync(error.filePath, 'utf8');
+
+  const firstLine = file.split('\n')[0];
+
+  // The whitespace after `eslint-disable` is important so `eslint-disable-next-line` and variants
+  // aren't picked up.
+  const matched = firstLine.match(/eslint-disable (.*)\*\//);
+
+  if (matched) {
+    const existing = matched[1].split(',').map((item) => item.trim());
+    uniqueIds = [...new Set([...ruleIds, ...existing])];
+    uniqueIds.sort((a, b) => a.localeCompare(b));
+
+    writeFileSync(
+      error.filePath,
+      file.replace(/^.*\n/, `/* eslint-disable ${uniqueIds.join(', ')} */\n`),
+    );
+  } else {
+    uniqueIds.sort((a, b) => a.localeCompare(b));
+    writeFileSync(
+      error.filePath,
+      `/* eslint-disable ${uniqueIds.join(', ')} */\n${file}`,
+    );
+  }
+}
+
+module.exports = async function ignoreAll(cwd = process.cwd()) {
+  const currentPackageJSON = require(join(cwd, 'package.json'));
+
+  const eslintVersion = currentPackageJSON.devDependencies.eslint;
+
+  let cli;
+  let report;
+  let results;
+
+  const eslint = importCwd('eslint');
+
+  if (semver.intersects(eslintVersion, '8')) {
+    // this won't use the version in the repo but it will still use v8 because
+    // that is installed in this repo
+    const { ESLint } = eslint;
+    cli = new ESLint();
+    results = await cli.lintFiles([cwd]);
+
+    // remove warnings
+    results = ESLint.getErrorResults(results);
+  } else {
+    const { CLIEngine, ESLint } = eslint;
+    cli = new CLIEngine();
+    report = cli.executeOnFiles([cwd]);
+    results = report.results;
+
+    // remove warnings
+    results = ESLint.getErrorResults(results);
+  }
+
+  const errors = results.filter((result) => result.errorCount > 0);
+
+  errors.forEach(ignoreError);
+};

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,0 +1,36 @@
+const { readFileSync, lstatSync } = require('fs');
+const { join } = require('path');
+const getFiles = require('./get-files');
+
+module.exports = function list(cwd = process.cwd()) {
+  const files = getFiles(cwd);
+
+  const output = {};
+
+  files.forEach((relativeFilePath) => {
+    const filePath = join(cwd, relativeFilePath);
+    // prevent odd times when directories might end with `.js` or `.ts`;
+    if (!lstatSync(filePath).isFile()) {
+      return;
+    }
+
+    const file = readFileSync(filePath, 'utf8');
+    const firstLine = file.split('\n')[0];
+    if (!firstLine.includes('eslint-disable ')) {
+      return;
+    }
+
+    const matched = firstLine.match(/eslint-disable (.*)\*\//);
+    const ignoreRules = matched[1].split(',').map((item) => item.trim());
+
+    ignoreRules.forEach((rule) => {
+      if (output[rule]) {
+        output[rule].push(filePath);
+      } else {
+        output[rule] = [filePath];
+      }
+    });
+  });
+
+  return output;
+};

--- a/lib/list.js
+++ b/lib/list.js
@@ -15,7 +15,16 @@ module.exports = function list(cwd = process.cwd()) {
     }
 
     const file = readFileSync(filePath, 'utf8');
-    const firstLine = file.split('\n')[0];
+    const splitFile = file.split('\n');
+    let firstLine = splitFile[0];
+
+    // shebang https://nodejs.org/en/learn/command-line/run-nodejs-scripts-from-the-command-line
+    let shebangFile = firstLine.startsWith('#!');
+
+    // the logical first line of the file is after the shebang
+    if (shebangFile) {
+      firstLine = splitFile[1];
+    }
     if (!firstLine.includes('eslint-disable ')) {
       return;
     }

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -1,0 +1,43 @@
+const { readFileSync, writeFileSync } = require('fs');
+const getFiles = require('./get-files');
+const { join } = require('path');
+
+function removeIgnore(filePath, rulename) {
+  const file = readFileSync(filePath, 'utf8');
+
+  const firstLine = file.split('\n')[0];
+
+  // The whitespace after `eslint-disable` is important so `eslint-disable-next-line` and variants
+  // aren't picked up.
+  const matched = firstLine.match(/eslint-disable (.*)\*\//);
+
+  if (matched) {
+    const existing = matched[1]
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item !== rulename);
+
+    if (existing.length) {
+      writeFileSync(
+        filePath,
+        file.replace(/^.*\n/, `/* eslint-disable ${existing.join(', ')} */\n`),
+      );
+    } else {
+      writeFileSync(filePath, file.replace(/^.*\n/, ''));
+    }
+  }
+}
+
+module.exports = function remove({ name, filter } = {}, cwd = process.cwd()) {
+  if (!name) {
+    throw new Error(
+      'No rulename was passed to `remove()` in lint-to-the-future-eslint plugin',
+    );
+  }
+
+  const files = getFiles(cwd, filter);
+
+  files.forEach((relativeFilePath) => {
+    removeIgnore(join(cwd, relativeFilePath), name);
+  });
+};

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -5,7 +5,16 @@ const { join } = require('path');
 function removeIgnore(filePath, rulename) {
   const file = readFileSync(filePath, 'utf8');
 
-  const firstLine = file.split('\n')[0];
+  const splitFile = file.split('\n');
+  let firstLine = splitFile[0];
+
+  // shebang https://nodejs.org/en/learn/command-line/run-nodejs-scripts-from-the-command-line
+  let shebangFile = firstLine.startsWith('#!');
+
+  // the logical first line of the file is after the shebang
+  if (shebangFile) {
+    firstLine = splitFile[1];
+  }
 
   // The whitespace after `eslint-disable` is important so `eslint-disable-next-line` and variants
   // aren't picked up.
@@ -18,13 +27,20 @@ function removeIgnore(filePath, rulename) {
       .filter((item) => item !== rulename);
 
     if (existing.length) {
-      writeFileSync(
-        filePath,
-        file.replace(/^.*\n/, `/* eslint-disable ${existing.join(', ')} */\n`),
+      splitFile.splice(
+        shebangFile ? 1 : 0, // if it's a shebangFile we start at the 2nd line of the file
+        1, // replacing the existing eslint-disable
+        `/* eslint-disable ${existing.join(', ')} */`,
       );
     } else {
-      writeFileSync(filePath, file.replace(/^.*\n/, ''));
+      // if we removed the last one we just remove the eslint-disable line
+      splitFile.splice(
+        shebangFile ? 1 : 0, // if it's a shebangFile we start at the 2nd line of the file
+        1,
+      );
     }
+
+    writeFileSync(filePath, splitFile.join('\n'));
   }
 }
 

--- a/test/ignore.mjs
+++ b/test/ignore.mjs
@@ -9,7 +9,7 @@ async function ignoreTestFile(input, files) {
   const project = new Project({
     files: {
       '.eslintrc.json': '{"extends": "eslint:recommended"}',
-      'test.js': input,
+      'index.js': input,
       'package.json': `{
         "devDependencies": {
           "eslint": "^7.0.0"
@@ -23,7 +23,7 @@ async function ignoreTestFile(input, files) {
   await project.write();
   await ignoreAll(project.baseDir);
 
-  return readFileSync(join(project.baseDir, 'test.js'), 'utf-8');
+  return readFileSync(join(project.baseDir, 'index.js'), 'utf-8');
 }
 
 describe('ignore function', function () {
@@ -90,5 +90,22 @@ debugger
 if (10 === 'false') {
   // something
 }`);
+  });
+
+  it('does the right thing with hash-bang/shebang files', async function () {
+    expect(
+      await ignoreTestFile(`#!/usr/bin/env node
+debugger`),
+    ).to.equal(`#!/usr/bin/env node
+/* eslint-disable no-debugger */
+debugger`);
+
+    expect(
+      await ignoreTestFile(`#!/usr/bin/env node
+/* eslint-disable some-other-lint */
+debugger`),
+    ).to.equal(`#!/usr/bin/env node
+/* eslint-disable no-debugger, some-other-lint */
+debugger`);
   });
 });

--- a/test/list.mjs
+++ b/test/list.mjs
@@ -3,37 +3,57 @@ import { Project } from 'fixturify-project';
 
 import { list } from '../index.js';
 
+async function listFiles(files) {
+  const project = new Project({
+    files,
+  });
+
+  await project.write();
+
+  const cwd = process.cwd();
+
+  process.chdir(project.baseDir);
+  const result = list('./');
+  process.chdir(cwd);
+  return result;
+}
+
 describe('list function', function () {
   it('should output object with rules and files', async function () {
-    const project = new Project({
-      files: {
-        'index.js': `/* eslint-disable no-unused-vars, prefer-const, quotes, semi  */
+    const result = await listFiles({
+      'index.js': `/* eslint-disable no-unused-vars, prefer-const, quotes, semi  */
 let unused = 'face';
 
 let b = () => {};
 `,
-        'next-line-ignore.js': `/* eslint-disable no-unused-vars, quotes, semi */
+      'next-line-ignore.js': `/* eslint-disable no-unused-vars, quotes, semi */
 const unused = 'face';
 
 // eslint-disable-next-line prefer-const
 let b = () => {};
 `,
-      },
     });
-
-    await project.write();
-
-    const cwd = process.cwd();
-
-    process.chdir(project.baseDir);
-    const result = list('./');
-    process.chdir(cwd);
 
     expect(result).to.deep.equal({
       'no-unused-vars': ['index.js', 'next-line-ignore.js'],
       'prefer-const': ['index.js'],
       quotes: ['index.js', 'next-line-ignore.js'],
       semi: ['index.js', 'next-line-ignore.js'],
+    });
+  });
+
+  it('should list properly with hash-bang/shebang files', async function () {
+    const result = await listFiles({
+      'index.js': `#! /env/node
+/* eslint-disable no-unused-vars  */
+let unused = 'face';
+
+let b = () => {};
+`,
+    });
+
+    expect(result).to.deep.equal({
+      'no-unused-vars': ['index.js'],
     });
   });
 });

--- a/test/remove.mjs
+++ b/test/remove.mjs
@@ -81,4 +81,19 @@ console.log('hello world');`);
       .equal(`/* eslint-disable face-lint, other-lint */
 console.log('hello bananananana!');`);
   });
+
+  it('should remove correctly from shebang files', async function () {
+    const project = await setupProject({
+      'test.js': `#! /usr/env node
+/* eslint-disable face-lint, other-lint */
+console.log('hello world');`,
+    });
+
+    remove({ name: 'face-lint', filter: 't*.js' }, project.baseDir);
+
+    expect(readFileSync(join(project.baseDir, 'test.js'), 'utf-8')).to
+      .equal(`#! /usr/env node
+/* eslint-disable other-lint */
+console.log('hello world');`);
+  });
 });


### PR DESCRIPTION
This is for files that have a `#! /usr/env node` or whatever at the start.

The first line needs to stay as a shebang or it breaks everything so we need to consider the **second line** of the file for file-based ignores 👍 