### PR TITLE
Update get-files.js to include GJS/GTS files by default

### DIFF
--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -6,7 +6,7 @@ export default function getFiles(cwd, providedGlob) {
   if (providedGlob) {
     globs = [providedGlob];
   } else {
-    globs = ['**/*.js', '**/*.ts'];
+    globs = ['**/*.js', '**/*.ts', '**/*.gjs', '**/*.gts'];
   }
 
   // globby's ignore functionality works by getting all glob matches and _then_ filtering them.

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -70,4 +70,23 @@ let b = () => {};
 
     expect(result).to.deep.equal({});
   });
+
+  it('should work for GJS/GTS files by default', async function () {
+    const result = await listFiles({
+      'index.gjs': `/* eslint-disable no-unused-vars  */
+  let unused = 'face';
+
+  let b = () => {};
+  `,
+      'other.gts': `/* eslint-disable no-unused-vars  */
+  let unused = 'face';
+
+  let b = () => {};
+  `,
+    });
+
+    expect(result).to.deep.equal({
+      'no-unused-vars': ['index.gjs', 'other.gts'],
+    });
+  })
 });


### PR DESCRIPTION
GJS & GTS files weren't being shown in the LTTF dashboard.