### PR TITLE
Support ESLint flat config while maintaining legacy .eslintrc compatibility

### DIFF
--- a/lib/ignore-all.js
+++ b/lib/ignore-all.js
@@ -2,7 +2,8 @@ import importCwd from 'import-cwd';
 import { readFileSync, writeFileSync } from 'fs';
 
 function ignoreError(error) {
-  const ruleIds = error.messages.map((message) => message.ruleId);
+  const ruleIds = error.messages
+    .map((message) => message.ruleId);
   let uniqueIds = [...new Set(ruleIds)].sort((a, b) => a.localeCompare(b));
 
   const file = readFileSync(error.filePath, 'utf8');
@@ -24,7 +25,9 @@ function ignoreError(error) {
   const matched = firstLine.match(/eslint-disable (.*)\*\//);
 
   if (matched) {
-    const existing = matched[1].split(',').map((item) => item.trim());
+    const existing = matched[1]
+      .split(',')
+      .map((item) => item.trim());
     uniqueIds = [...new Set([...ruleIds, ...existing])].sort((a, b) =>
       a.localeCompare(b),
     );
@@ -47,14 +50,16 @@ export default async function ignoreAll({ filter } = {}, cwd = process.cwd()) {
 
   // this won't use the version in the repo but it will still use v8 because
   // that is installed in this repo
-  const { ESLint } = eslint;
-  cli = new ESLint({
-    cwd,
-  });
+  // Prefer flat-config aware loader when available (ESLint >= 8.56). Fallback to legacy constructor
+  // for older ESLint, which is fine for .eslintrc-based projects.
+  const hasLoadESLint = typeof eslint.loadESLint === 'function';
+  const ESLint = hasLoadESLint ? await eslint.loadESLint({ cwd }) : eslint.ESLint;
+  cli = new ESLint({ cwd });
   results = await cli.lintFiles([filter ?? cwd]);
 
   // remove warnings
-  results = ESLint.getErrorResults(results);
+  const getErrorResults = ESLint.getErrorResults || (eslint.ESLint && eslint.ESLint.getErrorResults);
+  results = getErrorResults ? getErrorResults(results) : results;
 
   const errors = results.filter((result) => result.errorCount > 0);
 

--- a/lib/ignore-all.js
+++ b/lib/ignore-all.js
@@ -3,7 +3,8 @@ import { readFileSync, writeFileSync } from 'fs';
 
 function ignoreError(error) {
   const ruleIds = error.messages
-    .map((message) => message.ruleId);
+    .map((message) => message.ruleId)
+    .filter(Boolean);
   let uniqueIds = [...new Set(ruleIds)].sort((a, b) => a.localeCompare(b));
 
   const file = readFileSync(error.filePath, 'utf8');
@@ -27,7 +28,8 @@ function ignoreError(error) {
   if (matched) {
     const existing = matched[1]
       .split(',')
-      .map((item) => item.trim());
+      .map((item) => item.trim())
+      .filter(Boolean);
     uniqueIds = [...new Set([...ruleIds, ...existing])].sort((a, b) =>
       a.localeCompare(b),
     );

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/eslint-parser": "^7.19.1",
     "@eslint/js": "^9.14.0",
     "eslint": "^9.14.0",
+    "eslint-legacy": "npm:eslint@^8.0.0",
     "execa": "^9.5.2",
     "find-up": "^6.3.0",
     "fixturify-project": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vitest": "^3.0.5"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "packageManager": "pnpm@10.2.1+sha512.398035c7bd696d0ba0b10a688ed558285329d27ea994804a52bad9167d8e3a72bcb993f9699585d3ca25779ac64949ef422757a6c31102c12ab932e5cbe5cc92",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       eslint:
         specifier: ^9.14.0
         version: 9.20.0
+      eslint-legacy:
+        specifier: npm:eslint@^8.0.0
+        version: eslint@8.57.1
       execa:
         specifier: ^9.5.2
         version: 9.5.2
@@ -310,9 +313,17 @@ packages:
     resolution: {integrity: sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/eslintrc@2.1.4':
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   '@eslint/eslintrc@3.2.0':
     resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@8.57.1':
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@eslint/js@9.20.0':
     resolution: {integrity: sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==}
@@ -341,9 +352,18 @@ packages:
     resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
     engines: {node: '>=18.18.0'}
 
+  '@humanwhocodes/config-array@0.13.0':
+    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
+    engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
+
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
+
+  '@humanwhocodes/object-schema@2.0.3':
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@humanwhocodes/retry@0.3.1':
     resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
@@ -801,6 +821,9 @@ packages:
   '@types/ssri@7.1.5':
     resolution: {integrity: sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==}
 
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
   '@vitest/expect@3.0.5':
     resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
 
@@ -1108,6 +1131,10 @@ packages:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
 
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1158,6 +1185,10 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
+  eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   eslint-scope@8.2.0:
     resolution: {integrity: sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1174,6 +1205,12 @@ packages:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint@8.57.1:
+    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
+
   eslint@9.20.0:
     resolution: {integrity: sha512-aL4F8167Hg4IvsW89ejnpTwx+B/UQRzJPGgbIOl+4XqffWsahVVsLEWoZvnrVuwpWmnRd7XeXmQI1zlKcFDteA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1187,6 +1224,10 @@ packages:
   espree@10.3.0:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
@@ -1253,6 +1294,10 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
+  file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1276,6 +1321,10 @@ packages:
   fixturify@3.0.0:
     resolution: {integrity: sha512-PFOf/DT9/t2NCiVyiQ5cBMJtGZfWh3aeOV8XVqQQOPBlTv8r6l0k75/hm36JOaiJlrWFk/8aYFyOKAvOkrkjrw==}
     engines: {node: 14.* || >= 16.*}
+
+  flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -1369,6 +1418,10 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -1386,6 +1439,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1513,6 +1569,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
 
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
@@ -2309,6 +2369,9 @@ packages:
   temporal-spec@0.2.4:
     resolution: {integrity: sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==}
 
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -2825,6 +2888,20 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/eslintrc@2.1.4':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.0
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
@@ -2838,6 +2915,8 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@eslint/js@8.57.1': {}
 
   '@eslint/js@9.20.0': {}
 
@@ -2859,7 +2938,17 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.3.1
 
+  '@humanwhocodes/config-array@0.13.0':
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.4.0
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/object-schema@2.0.3': {}
 
   '@humanwhocodes/retry@0.3.1': {}
 
@@ -3398,6 +3487,8 @@ snapshots:
     dependencies:
       '@types/node': 22.13.1
 
+  '@ungap/structured-clone@1.3.0': {}
+
   '@vitest/expect@3.0.5':
     dependencies:
       '@vitest/spy': 3.0.5
@@ -3720,6 +3811,10 @@ snapshots:
 
   detect-libc@2.0.3: {}
 
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.96: {}
@@ -3786,6 +3881,11 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  eslint-scope@7.2.2:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-scope@8.2.0:
     dependencies:
       esrecurse: 4.3.0
@@ -3796,6 +3896,49 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.0: {}
+
+  eslint@8.57.1:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.57.1
+      '@humanwhocodes/config-array': 0.13.0
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.3.0
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.24.0
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
 
   eslint@9.20.0:
     dependencies:
@@ -3841,6 +3984,12 @@ snapshots:
       acorn: 8.14.0
       acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 4.2.0
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
+      eslint-visitor-keys: 3.4.3
 
   esquery@1.6.0:
     dependencies:
@@ -3927,6 +4076,10 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
+  file-entry-cache@6.0.1:
+    dependencies:
+      flat-cache: 3.2.0
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3971,6 +4124,12 @@ snapshots:
       fs-extra: 10.1.0
       matcher-collection: 2.0.1
       walk-sync: 3.0.0
+
+  flat-cache@3.2.0:
+    dependencies:
+      flatted: 3.3.2
+      keyv: 4.5.4
+      rimraf: 3.0.2
 
   flat-cache@4.0.1:
     dependencies:
@@ -4089,6 +4248,10 @@ snapshots:
 
   globals@11.12.0: {}
 
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
+
   globals@14.0.0: {}
 
   globals@15.14.0: {}
@@ -4105,6 +4268,8 @@ snapshots:
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
+
+  graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
 
@@ -4210,6 +4375,8 @@ snapshots:
   is-lambda@1.0.1: {}
 
   is-number@7.0.0: {}
+
+  is-path-inside@3.0.3: {}
 
   is-plain-obj@2.1.0: {}
 
@@ -4967,6 +5134,8 @@ snapshots:
       temporal-spec: 0.2.4
 
   temporal-spec@0.2.4: {}
+
+  text-table@0.2.0: {}
 
   thenify-all@1.6.0:
     dependencies:

--- a/test/flat-config.test.js
+++ b/test/flat-config.test.js
@@ -1,0 +1,51 @@
+import { Project } from 'fixturify-project';
+import { describe, it, expect } from 'vitest';
+import { ignoreAll } from '../main.mjs';
+
+async function runWithFlatConfig(files, options) {
+  const project = new Project({
+    files: {
+      // Flat config only (no .eslintrc.*)
+      'eslint.config.js': `const js = require('@eslint/js');
+
+module.exports = [
+  js.configs.recommended,
+  // ensure ESM syntax parses when flat config is used
+  { languageOptions: { sourceType: 'module' } },
+];`,
+      'index.js': '',
+      'package.json': `{
+        "devDependencies": {
+          "eslint": "^9.0.0"
+        }
+      }`,
+      ...files,
+    },
+  });
+
+  // Use the repo's devDependency version of eslint
+  project.linkDevDependency('eslint', { baseDir: process.cwd() });
+  project.linkDevDependency('@eslint/js', { baseDir: process.cwd() });
+  await project.write();
+
+  await ignoreAll(options ?? {}, project.baseDir);
+
+  project.readSync(project.baseDir);
+  return project.files;
+}
+
+describe('flat config support', () => {
+  it('uses flat config when present and does not produce blanket disables', async () => {
+    const files = await runWithFlatConfig({
+      // Valid ESM with a real error (no-debugger)
+      'index.js': `import x from 'y'
+debugger`,
+    });
+
+    expect(files['index.js']).toEqual(`/* eslint-disable no-debugger, no-unused-vars */
+import x from 'y'
+debugger`);
+  });
+});
+
+

--- a/test/flat-config.test.js
+++ b/test/flat-config.test.js
@@ -1,8 +1,8 @@
 import { Project } from 'fixturify-project';
 import { describe, it, expect } from 'vitest';
-import { ignoreAll } from '../main.mjs';
+import { execa } from 'execa';
 
-async function runWithFlatConfig(files, options) {
+async function runWithFlatConfig(files) {
   const project = new Project({
     files: {
       // Flat config only (no .eslintrc.*)
@@ -26,9 +26,12 @@ module.exports = [
   // Use the repo's devDependency version of eslint
   project.linkDevDependency('eslint', { baseDir: process.cwd() });
   project.linkDevDependency('@eslint/js', { baseDir: process.cwd() });
+  project.linkDevDependency('lint-to-the-future', { baseDir: process.cwd() });
+  project.linkDevDependency('lint-to-the-future-eslint', { baseDir: process.cwd() });
   await project.write();
 
-  await ignoreAll(options ?? {}, project.baseDir);
+  // Run ignoreAll against the project directory
+  await execa({cwd: project.baseDir})`npx lttf ignore`;
 
   project.readSync(project.baseDir);
   return project.files;

--- a/test/ignore.test.js
+++ b/test/ignore.test.js
@@ -148,5 +148,21 @@ debugger`);
       debugger",
       }
     `)
-  })
+  });
+
+  it('should not produce double commas when merging with existing disable comments', async function () {
+    expect(
+      (await ignoreTestFile(`/* eslint-disable ember/no-classic-classes, ember/no-classic-components */
+debugger`))['index.js'],
+    ).to.equal(`/* eslint-disable ember/no-classic-classes, ember/no-classic-components, no-debugger */
+debugger`);
+  });
+
+  it('should handle existing disable comments with empty entries gracefully', async function () {
+    expect(
+      (await ignoreTestFile(`/* eslint-disable ember/no-classic-classes, , ember/no-classic-components */
+debugger`))['index.js'],
+    ).to.equal(`/* eslint-disable ember/no-classic-classes, ember/no-classic-components, no-debugger */
+debugger`);
+  });
 });

--- a/test/legacy-fallback.test.js
+++ b/test/legacy-fallback.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Project } from 'fixturify-project';
+import path from 'path';
+
+// Mock import-cwd so that importCwd('eslint') returns a legacy-like API
+vi.mock('import-cwd', () => {
+  const mockESLintCtor = class {
+    constructor(options = {}) {
+      this.options = options;
+    }
+    async lintFiles() {
+      // minimal legacy-like result: one file with one error
+      return [
+        {
+          filePath: path.join(this.options.cwd || process.cwd(), 'index.js'),
+          errorCount: 1,
+          messages: [{ ruleId: 'no-debugger' }],
+        },
+      ];
+    }
+  };
+  // static method used by plugin to strip warnings
+  mockESLintCtor.getErrorResults = (results) => results;
+
+  // default export is a function(name) => module
+  const importCwd = (name) => {
+    if (name === 'eslint') {
+      return { ESLint: mockESLintCtor };
+    }
+    throw new Error(`Unexpected import-cwd request: ${name}`);
+  };
+  return { default: importCwd };
+});
+
+import { ignoreAll } from '../main.mjs';
+
+describe('legacy fallback (no loadESLint)', () => {
+  it('falls back to legacy ESLint constructor and writes rule-specific disable', async () => {
+    const project = new Project({
+      files: {
+        // Legacy only project: no eslint.config.js
+        '.eslintrc.json': '{"extends": "eslint:recommended"}',
+        'index.js': 'debugger',
+        'package.json': '{"devDependencies": {"eslint": "^7.0.0"}}',
+      },
+    });
+
+    // create node_modules structure similarly to other tests
+    project.linkDevDependency('eslint', { baseDir: process.cwd() });
+    await project.write();
+
+    // Run ignoreAll against the project directory
+    await ignoreAll({}, project.baseDir);
+
+    project.readSync(project.baseDir);
+    expect(project.files['index.js']).toEqual(`/* eslint-disable no-debugger */
+debugger`);
+  });
+});
+
+

--- a/test/legacy-fallback.test.js
+++ b/test/legacy-fallback.test.js
@@ -1,38 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { Project } from 'fixturify-project';
-import path from 'path';
-
-// Mock import-cwd so that importCwd('eslint') returns a legacy-like API
-vi.mock('import-cwd', () => {
-  const mockESLintCtor = class {
-    constructor(options = {}) {
-      this.options = options;
-    }
-    async lintFiles() {
-      // minimal legacy-like result: one file with one error
-      return [
-        {
-          filePath: path.join(this.options.cwd || process.cwd(), 'index.js'),
-          errorCount: 1,
-          messages: [{ ruleId: 'no-debugger' }],
-        },
-      ];
-    }
-  };
-  // static method used by plugin to strip warnings
-  mockESLintCtor.getErrorResults = (results) => results;
-
-  // default export is a function(name) => module
-  const importCwd = (name) => {
-    if (name === 'eslint') {
-      return { ESLint: mockESLintCtor };
-    }
-    throw new Error(`Unexpected import-cwd request: ${name}`);
-  };
-  return { default: importCwd };
-});
-
-import { ignoreAll } from '../main.mjs';
+import { execa } from 'execa';
 
 describe('legacy fallback (no loadESLint)', () => {
   it('falls back to legacy ESLint constructor and writes rule-specific disable', async () => {
@@ -45,12 +13,14 @@ describe('legacy fallback (no loadESLint)', () => {
       },
     });
 
-    // create node_modules structure similarly to other tests
-    project.linkDevDependency('eslint', { baseDir: process.cwd() });
+    // we're linking to eslint-legacy here because that is the behaviour that we're testing
+    project.linkDevDependency('eslint', { baseDir: process.cwd(), resolveName: 'eslint-legacy' });
+    project.linkDevDependency('lint-to-the-future', { baseDir: process.cwd() });
+    project.linkDevDependency('lint-to-the-future-eslint', { baseDir: process.cwd() });
     await project.write();
 
     // Run ignoreAll against the project directory
-    await ignoreAll({}, project.baseDir);
+    await execa({cwd: project.baseDir})`npx lttf ignore`;
 
     project.readSync(project.baseDir);
     expect(project.files['index.js']).toEqual(`/* eslint-disable no-debugger */


### PR DESCRIPTION
## Add ESLint flat config support with backward compatibility

The plugin currently uses ESLint's legacy constructor which doesn't respect flat config files (`eslint.config.mjs`), causing it to add blanket `/* eslint-disable */` to every js/ts file.

**fix**: 
- Use `eslint.loadESLint({ cwd })` when available for flat config support
- Fall back to legacy `eslint.ESLint` for older versions

I also noticed a bug where nullish lint rule ids were not filtered out which leads to things like `/* eslint-disable some-valid-rule, , , another-valid-rule */`
- Fix comma bug when merging existing disable rules

**Changes**:
- Update `ignoreAll()` to dynamically load appropriate ESLint constructor
- Add `.filter(Boolean)` to prevent undefined/null rule IDs and empty entries
- Maintain full backward compatibility with `.eslintrc` projects

**Testing**: Added `flat-config.test.js` and `legacy-fallback.test.js` to verify both scenarios work correctly.
