### PR TITLE
feat: enable concurrency setting to be passed to eslint

### DIFF
--- a/lib/ignore-all.js
+++ b/lib/ignore-all.js
@@ -44,7 +44,7 @@ function ignoreError(error) {
   writeFileSync(error.filePath, splitFile.join('\n'));
 }
 
-export default async function ignoreAll({ filter } = {}, cwd = process.cwd()) {
+export default async function ignoreAll({ filter, concurrency } = {}, cwd = process.cwd()) {
   let cli;
   let results;
 
@@ -56,7 +56,8 @@ export default async function ignoreAll({ filter } = {}, cwd = process.cwd()) {
   // for older ESLint, which is fine for .eslintrc-based projects.
   const hasLoadESLint = typeof eslint.loadESLint === 'function';
   const ESLint = hasLoadESLint ? await eslint.loadESLint({ cwd }) : eslint.ESLint;
-  cli = new ESLint({ cwd });
+  const jobs = concurrency || 'auto';
+  cli = new ESLint({ cwd, concurrency: jobs });
   results = await cli.lintFiles([filter ?? cwd]);
 
   // remove warnings


### PR DESCRIPTION
will require passing the value from within lint-to-the-future.

Alternatively we can also read from env...